### PR TITLE
feat: configure OpenAI and Ozon services

### DIFF
--- a/Options/OpenAiOptions.cs
+++ b/Options/OpenAiOptions.cs
@@ -1,0 +1,8 @@
+namespace ai_it_wiki.Options
+{
+  public class OpenAiOptions
+  {
+    public string ApiKey { get; set; } = string.Empty;
+    public string Proxy { get; set; } = string.Empty;
+  }
+}

--- a/Options/OzonOptions.cs
+++ b/Options/OzonOptions.cs
@@ -1,0 +1,9 @@
+namespace ai_it_wiki.Options
+{
+  public class OzonOptions
+  {
+    public string ClientId { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+    public string BaseUrl { get; set; } = string.Empty;
+  }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,8 @@ using ai_it_wiki.Models;
 using ai_it_wiki.Services.OpenAI;
 using ai_it_wiki.Services.TelegramBot;
 using ai_it_wiki.Services.Youtube;
+using ai_it_wiki.Services.Ozon;
+using ai_it_wiki.Options;
 
 using Kwork;
 
@@ -43,6 +45,7 @@ builder.Services
 //  e.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
 //});
 var services = new ServiceCollection();
+// TODO[recommended]: рассмотреть удаление неиспользуемой коллекции services
 
 var mySqlConnectionString = builder.Configuration.GetConnectionString("context");
 
@@ -139,8 +142,11 @@ builder.WebHost.ConfigureKestrel(options =>
 });
 
 
-// Add OpenAIService
-builder.Services.AddSingleton<OpenAIService>(new OpenAIService(builder.Configuration["Api:OpenAI"], builder.Configuration["Proxy:String"]));
+builder.Services.Configure<OzonOptions>(builder.Configuration.GetSection("Ozon"));
+builder.Services.Configure<OpenAiOptions>(builder.Configuration.GetSection("OpenAI"));
+builder.Services.AddHttpClient<IOzonApiService, OzonApiService>();
+builder.Services.AddSingleton<OpenAIService>();
+builder.Services.AddSingleton<IOpenAiService>(sp => sp.GetRequiredService<OpenAIService>());
 builder.Services.AddSingleton<KworkManager>();
 
 builder.Services.AddSingleton<YoutubeService>();

--- a/Services/OpenAI/OpenAIService.cs
+++ b/Services/OpenAI/OpenAIService.cs
@@ -1,6 +1,7 @@
 ﻿using ai_it_wiki.Controllers;
 using ai_it_wiki.Data;
 using ai_it_wiki.Models;
+using ai_it_wiki.Options;
 
 using Newtonsoft.Json;
 
@@ -8,6 +9,7 @@ using NuGet.Packaging;
 
 using OpenAI_API;
 using OpenAI_API.Chat;
+using Microsoft.Extensions.Options;
 
 using System.Text;
 
@@ -20,9 +22,12 @@ namespace ai_it_wiki.Services.OpenAI
 {
   public class OpenAIService : OpenAIAPI, IOpenAiService
   {
-    public OpenAIService(string apiKey, string proxyString) : base(new APIAuthentication(apiKey))
+    private readonly OpenAiOptions _options;
+
+    public OpenAIService(IOptions<OpenAiOptions> options) : base(new APIAuthentication(options.Value.ApiKey))
     {
-      HttpClientFactory = new Internal.HttpProxyClientFactory(proxyString);
+      _options = options.Value;
+      HttpClientFactory = new Internal.HttpProxyClientFactory(_options.Proxy);
     }
 
     public async Task<string> SendMessageAsync(DialogSettings dialogSettings, string text)

--- a/Services/Ozon/IOzonApiService.cs
+++ b/Services/Ozon/IOzonApiService.cs
@@ -1,0 +1,6 @@
+namespace ai_it_wiki.Services.Ozon
+{
+  public interface IOzonApiService
+  {
+  }
+}

--- a/Services/Ozon/OzonApiService.cs
+++ b/Services/Ozon/OzonApiService.cs
@@ -1,0 +1,22 @@
+using ai_it_wiki.Options;
+using Microsoft.Extensions.Options;
+using System;
+using System.Net.Http;
+
+namespace ai_it_wiki.Services.Ozon
+{
+  public class OzonApiService : IOzonApiService
+  {
+    private readonly HttpClient _httpClient;
+    private readonly OzonOptions _options;
+
+    public OzonApiService(HttpClient httpClient, IOptions<OzonOptions> options)
+    {
+      _httpClient = httpClient;
+      _options = options.Value;
+      _httpClient.BaseAddress = new Uri(_options.BaseUrl);
+      _httpClient.DefaultRequestHeaders.Add("Client-Id", _options.ClientId);
+      _httpClient.DefaultRequestHeaders.Add("Api-Key", _options.ApiKey);
+    }
+  }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Ozon": {
+    "ClientId": "",
+    "ApiKey": "",
+    "BaseUrl": ""
+  },
+  "OpenAI": {
+    "ApiKey": "",
+    "Proxy": ""
+  }
+}


### PR DESCRIPTION
## Summary
- add configuration sections for Ozon and OpenAI
- register IOzonApiService and IOpenAiService with options support
- implement basic Ozon API service and options classes

## Testing
- `dotnet build` *(fails: The local source '/workspace/ai_it_wiki/C:/Program Files/DevExpress 24.1/DevExtreme/System/DevExtreme/Bin/AspNetCore' doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a20bfbcee0832f9641dbc3f634e1fa