### PR TITLE
Добавлены модели запросов/ответов Ozon ProductInfoList

### DIFF
--- a/Models/Ozon/ProductInfoListRequest.cs
+++ b/Models/Ozon/ProductInfoListRequest.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ai_it_wiki.Models.Ozon
+{
+  public class ProductInfoListRequest
+  {
+    [JsonPropertyName("filter")]
+    public ProductInfoListFilter Filter { get; set; }
+
+    [JsonPropertyName("last_id")]
+    public string LastId { get; set; }
+
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+  }
+
+  public class ProductInfoListFilter
+  {
+    [JsonPropertyName("offer_ids")]
+    public List<string> OfferIds { get; set; }
+
+    [JsonPropertyName("product_ids")]
+    public List<long> ProductIds { get; set; }
+
+    [JsonPropertyName("skus")]
+    public List<string> Skus { get; set; }
+  }
+}

--- a/Models/Ozon/ProductInfoListResponse.cs
+++ b/Models/Ozon/ProductInfoListResponse.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ai_it_wiki.Models.Ozon
+{
+  public class ProductInfoListResponse
+  {
+    [JsonPropertyName("items")]
+    public List<ProductItem> Items { get; set; }
+
+    [JsonPropertyName("total")]
+    public int Total { get; set; }
+
+    [JsonPropertyName("last_id")]
+    public string LastId { get; set; }
+  }
+
+  public class ProductItem
+  {
+    [JsonPropertyName("offer_id")]
+    public string OfferId { get; set; }
+
+    [JsonPropertyName("product_id")]
+    public long ProductId { get; set; }
+
+    [JsonPropertyName("sku")]
+    public string Sku { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("description_category_id")]
+    public long DescriptionCategoryId { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public List<ProductAttribute> Attributes { get; set; }
+  }
+
+  public class ProductAttribute
+  {
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+
+    [JsonPropertyName("values")]
+    public List<string> Values { get; set; }
+  }
+}


### PR DESCRIPTION
## Изменения
- добавлены модели `ProductInfoListRequest` и `ProductInfoListResponse` для работы с API Ozon
- класс `Attribute` переименован в `ProductAttribute`, поле `Sku` стало строковым

## Проверки
- `dotnet build` *(падает: не найден локальный источник пакетов DevExpress)*

------
https://chatgpt.com/codex/tasks/task_e_68a21e0bae28832fb57be533795a162f