### PR TITLE
Унификация SKU и DI в LLMOpenAPIController

### DIFF
--- a/Services/Ozon/IOzonClient.cs
+++ b/Services/Ozon/IOzonClient.cs
@@ -4,7 +4,7 @@ namespace ai_it_wiki.Services.Ozon
 {
     public interface IOzonClient
     {
-        Task<int> GetRatingAsync(long sku);
-        Task UpdateCardAsync(long sku);
+        Task<int> GetRatingAsync(string sku);
+        Task UpdateCardAsync(string sku);
     }
 }

--- a/Services/Ozon/OzonClientStub.cs
+++ b/Services/Ozon/OzonClientStub.cs
@@ -5,15 +5,15 @@ namespace ai_it_wiki.Services.Ozon
 {
     public class OzonClientStub : IOzonClient
     {
-        public Task<int> GetRatingAsync(long sku)
+        public Task<int> GetRatingAsync(string sku)
         {
-            // TODO: запрос к Ozon API для получения рейтинга
+            // TODO[critical]: реализовать запрос к Ozon API для получения рейтинга
             return Task.FromResult(0);
         }
 
-        public Task UpdateCardAsync(long sku)
+        public Task UpdateCardAsync(string sku)
         {
-            // TODO: обновление карточки товара через Ozon API
+            // TODO[critical]: реализовать обновление карточки товара через Ozon API
             return Task.CompletedTask;
         }
     }

--- a/Services/Ozon/ProductRatingOptimizer.cs
+++ b/Services/Ozon/ProductRatingOptimizer.cs
@@ -8,7 +8,7 @@ namespace ai_it_wiki.Services.Ozon
   public class ProductRatingOptimizer
   {
     private readonly IOzonClient _client;
-    private readonly HashSet<long> _optimizedSkus;
+    private readonly HashSet<string> _optimizedSkus;
     private const string StateFile = "Data/optimized_skus.json";
     private const int DelayMilliseconds = 1000; // Added missing constant  
 
@@ -21,7 +21,7 @@ namespace ai_it_wiki.Services.Ozon
       _optimizedSkus = LoadState();
     }
 
-    public async Task OptimizeSkuAsync(long sku)
+    public async Task OptimizeSkuAsync(string sku)
     {
       if (_optimizedSkus.Contains(sku))
       {
@@ -31,7 +31,7 @@ namespace ai_it_wiki.Services.Ozon
       var rating = await _client.GetRatingAsync(sku);
       if (rating >= 100)
       {
-        // TODO[recommended]: логгировать пропуск  
+        // TODO[recommended]: логгировать пропуск
         _optimizedSkus.Add(sku);
         SaveState();
         return;
@@ -55,27 +55,27 @@ namespace ai_it_wiki.Services.Ozon
       }
     }
 
-    private HashSet<long> LoadState()
+    private HashSet<string> LoadState()
     {
       if (!File.Exists(StateFile))
       {
-        return new HashSet<long>();
+        return new HashSet<string>();
       }
 
       try
       {
         var json = File.ReadAllText(StateFile);
-        return JsonSerializer.Deserialize<HashSet<long>>(json) ?? new HashSet<long>();
+        return JsonSerializer.Deserialize<HashSet<string>>(json) ?? new HashSet<string>();
       }
       catch (IOException)
       {
-        // Optionally log the error  
-        return new HashSet<long>();
+        // Optionally log the error
+        return new HashSet<string>();
       }
       catch (UnauthorizedAccessException)
       {
-        // Optionally log the error  
-        return new HashSet<long>();
+        // Optionally log the error
+        return new HashSet<string>();
       }
     }
 


### PR DESCRIPTION
## Summary
- унифицирован тип SKU и удалено использование `OzonClientStub`
- метод `OptimizeSku` переведен на DI-сервисы Ozon и OpenAI
- подготовлены заглушки `IOzonClient` и `OzonClientStub` к работе со строковыми SKU

## Testing
- `dotnet build` *(ошибка: OpenAI namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a375b93610832fb206bbf9c1d8140b