### PR TITLE
Добавлены повторные попытки и fallback для OpenAI

### DIFF
--- a/Services/OpenAI/IOpenAiService.cs
+++ b/Services/OpenAI/IOpenAiService.cs
@@ -13,7 +13,6 @@ namespace ai_it_wiki.Services.OpenAI
     /// <param name="cancellationToken">Токен отмены</param>
     /// <returns>Строка с улучшенным контентом</returns>
     Task<string> GenerateImprovedContentAsync(string productInfo, string productDescription, CancellationToken cancellationToken = default);
-    // TODO[moderate]: Реализовать метод генерации контента через OpenAI
   }
 }
 


### PR DESCRIPTION
## Summary
- реализована повторная отправка запросов и резервная модель для ошибок OpenAI
- добавлено ручное прерывание через CancellationToken
- удалён устаревший TODO в интерфейсе

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a3a3048c6c832fa875f7d4bfd3eca0