### PR TITLE
Добавлено логирование и очистка using в OpenAIService

### DIFF
--- a/Services/OpenAI/OpenAIService.cs
+++ b/Services/OpenAI/OpenAIService.cs
@@ -1,13 +1,10 @@
-﻿using ai_it_wiki.Controllers;
-using ai_it_wiki.Data;
+using ai_it_wiki.Controllers;
 using ai_it_wiki.Models;
 using ai_it_wiki.Options;
 
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-
 using NuGet.Packaging;
-
 using Microsoft.Extensions.Options;
 
 using System.Net.Http;
@@ -18,9 +15,6 @@ using Tiktoken;
 
 using OpenAI_API;
 using OpenAI_API.Chat;
-
-
-using static System.Net.Mime.MediaTypeNames;
 using static OpenAI_API.Chat.ChatMessage;
 
 namespace ai_it_wiki.Services.OpenAI
@@ -28,11 +22,14 @@ namespace ai_it_wiki.Services.OpenAI
   public class OpenAIService : OpenAIAPI, IOpenAiService
   {
     private readonly OpenAiOptions _options;
+    private readonly ILogger<OpenAIService> _logger;
 
-    public OpenAIService(IOptions<OpenAiOptions> options) : base(new APIAuthentication(options.Value.ApiKey))
+    public OpenAIService(IOptions<OpenAiOptions> options, ILogger<OpenAIService> logger)
+      : base(new APIAuthentication(options.Value.ApiKey))
     {
       _options = options.Value;
       HttpClientFactory = new Internal.HttpProxyClientFactory(_options.Proxy);
+      _logger = logger;
     }
 
     private async Task<string> ExecuteWithRetryAsync(ChatRequest chatRequest, CancellationToken cancellationToken)
@@ -69,7 +66,7 @@ namespace ai_it_wiki.Services.OpenAI
 
     public async Task<string> SendMessageAsync(DialogSettings dialogSettings, string text, CancellationToken cancellationToken = default)
     {
-     // _logger.LogInformation("Отправка сообщения в OpenAI: {Text}", text);
+     _logger.LogInformation("Отправка сообщения в OpenAI: {Text}", text);
       var chatRequest = new ChatRequest()
       {
         MaxTokens = 4000,
@@ -83,7 +80,7 @@ namespace ai_it_wiki.Services.OpenAI
 
     public async Task<string> SendMessageAsync(string text, CancellationToken cancellationToken = default)
     {
-     // _logger.LogInformation("Отправка сообщения в OpenAI: {Text}", text);
+     _logger.LogInformation("Отправка сообщения в OpenAI: {Text}", text);
       var chatRequest = new ChatRequest()
       {
         MaxTokens = 4000,
@@ -97,7 +94,7 @@ namespace ai_it_wiki.Services.OpenAI
 
     public async void SendMessageWithStreamAsync(string text, Action<ChatResult> callBack)
     {
-     // _logger.LogInformation("Стриминговый запрос в OpenAI: {Text}", text);
+     _logger.LogInformation("Стриминговый запрос в OpenAI: {Text}", text);
       ChatRequest chatRequest = new ChatRequest()
       {
         MaxTokens = 8000,
@@ -108,27 +105,27 @@ namespace ai_it_wiki.Services.OpenAI
       try
       {
         await Chat.StreamChatAsync(chatRequest, callBack);
-       // _logger.LogInformation("Стриминговый ответ получен");
+       _logger.LogInformation("Стриминговый ответ получен");
       }
       catch (HttpRequestException ex)
       {
-       // _logger.LogError(ex, "Сетевая ошибка при стриминговом запросе к OpenAI");
+       _logger.LogError(ex, "Сетевая ошибка при стриминговом запросе к OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
       }
       catch (TaskCanceledException ex)
       {
-       // _logger.LogError(ex, "Таймаут при стриминговом запросе к OpenAI");
+       _logger.LogError(ex, "Таймаут при стриминговом запросе к OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
       }
       catch (Exception ex)
       {
-       // _logger.LogError(ex, "Неожиданная ошибка при стриминговом запросе к OpenAI");
+       _logger.LogError(ex, "Неожиданная ошибка при стриминговом запросе к OpenAI");
       }
     }
 
     public async Task<int> SendMessageWithStreamAsync(List<ChatMessage> chatMessages, Action<ChatResult> callBack, string systemMessage = "Ты полезный ассистент", int maxTokens = 8000, string model = "gpt-40")
     {
-     // _logger.LogInformation("Стриминговый запрос в OpenAI с {Count} сообщениями", chatMessages.Count);
+     _logger.LogInformation("Стриминговый запрос в OpenAI с {Count} сообщениями", chatMessages.Count);
       //счетаем количество токенов
       int tokens = 0;
       var encoder = ModelToEncoder.For("gpt-4o");
@@ -148,21 +145,21 @@ namespace ai_it_wiki.Services.OpenAI
       try
       {
         await Chat.StreamChatAsync(chatRequest, callBack);
-       // _logger.LogInformation("Стриминговый ответ получен");
+       _logger.LogInformation("Стриминговый ответ получен");
       }
       catch (HttpRequestException ex)
       {
-       // _logger.LogError(ex, "Сетевая ошибка при стриминговом запросе к OpenAI");
+       _logger.LogError(ex, "Сетевая ошибка при стриминговом запросе к OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
       }
       catch (TaskCanceledException ex)
       {
-       // _logger.LogError(ex, "Таймаут при стриминговом запросе к OpenAI");
+       _logger.LogError(ex, "Таймаут при стриминговом запросе к OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
       }
       catch (Exception ex)
       {
-       // _logger.LogError(ex, "Неожиданная ошибка при стриминговом запросе к OpenAI");
+       _logger.LogError(ex, "Неожиданная ошибка при стриминговом запросе к OpenAI");
       }
       return tokens;
     }
@@ -186,7 +183,7 @@ namespace ai_it_wiki.Services.OpenAI
 
     public async Task<Move> GetNextMoveWithHistory(List<List<int>> board, Move lastMove, List<MoveRecord> moveHistory, string tactic)
     {
-     // _logger.LogInformation("Получение следующего хода для игры в ГО");
+     _logger.LogInformation("Получение следующего хода для игры в ГО");
       // Преобразуем состояние доски в строку
       string boardState = JsonConvert.SerializeObject(board).Replace("],[", "\n").Replace("]]", string.Empty).Replace("[[", string.Empty);
 
@@ -236,24 +233,24 @@ namespace ai_it_wiki.Services.OpenAI
       }
       catch (HttpRequestException ex)
       {
-       // _logger.LogError(ex, "Сетевая ошибка при запросе следующего хода к OpenAI");
+       _logger.LogError(ex, "Сетевая ошибка при запросе следующего хода к OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         throw;
       }
       catch (TaskCanceledException ex)
       {
-       // _logger.LogError(ex, "Таймаут при запросе следующего хода к OpenAI");
+       _logger.LogError(ex, "Таймаут при запросе следующего хода к OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         throw;
       }
       catch (JsonException ex)
       {
-       // _logger.LogError(ex, "Ошибка разбора ответа OpenAI");
+       _logger.LogError(ex, "Ошибка разбора ответа OpenAI");
         throw;
       }
       catch (Exception ex)
       {
-       // _logger.LogError(ex, "Неожиданная ошибка при запросе следующего хода к OpenAI");
+       _logger.LogError(ex, "Неожиданная ошибка при запросе следующего хода к OpenAI");
         throw;
       }
     }
@@ -261,7 +258,7 @@ namespace ai_it_wiki.Services.OpenAI
     //метод отправки фотографии на распознование
     public async Task<string> SendPhotoAsync(string photo, string comment = null)
     {
-     // _logger.LogInformation("Отправка изображения в OpenAI");
+     _logger.LogInformation("Отправка изображения в OpenAI");
       var chatRequest = new ChatRequest()
       {
         MaxTokens = 8000,
@@ -282,60 +279,60 @@ namespace ai_it_wiki.Services.OpenAI
       {
         var answer = await Chat.CreateChatCompletionAsync(chatRequest);
         var result = answer.Choices[0].Message.TextContent;
-       // _logger.LogInformation("Ответ OpenAI по изображению получен");
+       _logger.LogInformation("Ответ OpenAI по изображению получен");
         return result;
       }
       catch (HttpRequestException ex)
       {
-       // _logger.LogError(ex, "Сетевая ошибка при отправке изображения в OpenAI");
+       _logger.LogError(ex, "Сетевая ошибка при отправке изображения в OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         throw;
       }
       catch (TaskCanceledException ex)
       {
-       // _logger.LogError(ex, "Таймаут при отправке изображения в OpenAI");
+       _logger.LogError(ex, "Таймаут при отправке изображения в OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         throw;
       }
       catch (Exception ex)
       {
-       // _logger.LogError(ex, "Неожиданная ошибка при отправке изображения в OpenAI");
+       _logger.LogError(ex, "Неожиданная ошибка при отправке изображения в OpenAI");
         throw;
       }
     }
 
     public async Task<List<OpenAI_API.Models.Model>> GetModelsAsync()
     {
-     // _logger.LogInformation("Получение списка моделей OpenAI");
+     _logger.LogInformation("Получение списка моделей OpenAI");
       try
       {
         var models = Models;
         var result = await models.GetModelsAsync();
-       // _logger.LogInformation("Получено моделей: {Count}", result.Count);
+       _logger.LogInformation("Получено моделей: {Count}", result.Count);
         return result;
       }
       catch (HttpRequestException ex)
       {
-       // _logger.LogError(ex, "Сетевая ошибка при получении списка моделей");
+       _logger.LogError(ex, "Сетевая ошибка при получении списка моделей");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         throw;
       }
       catch (TaskCanceledException ex)
       {
-       // _logger.LogError(ex, "Таймаут при получении списка моделей");
+       _logger.LogError(ex, "Таймаут при получении списка моделей");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         throw;
       }
       catch (Exception ex)
       {
-       // _logger.LogError(ex, "Неожиданная ошибка при получении списка моделей");
+       _logger.LogError(ex, "Неожиданная ошибка при получении списка моделей");
         throw;
       }
     }
 
     public async Task<string> SendDataToChatGPTAsync(string telemetryData)
     {
-     // _logger.LogInformation("Отправка телеметрии в OpenAI");
+     _logger.LogInformation("Отправка телеметрии в OpenAI");
       // Формируем запрос к ChatGPT
       var chatRequest = new ChatRequest()
       {
@@ -364,26 +361,26 @@ namespace ai_it_wiki.Services.OpenAI
       }
       catch (HttpRequestException ex)
       {
-       // _logger.LogError(ex, "Сетевая ошибка при отправке телеметрии в OpenAI");
+       _logger.LogError(ex, "Сетевая ошибка при отправке телеметрии в OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         result = ex.Message;
       }
       catch (TaskCanceledException ex)
       {
-       // _logger.LogError(ex, "Таймаут при отправке телеметрии в OpenAI");
+       _logger.LogError(ex, "Таймаут при отправке телеметрии в OpenAI");
         // TODO[critical]: реализовать повторные попытки и fallback-сценарии
         result = ex.Message;
       }
       catch (Exception ex)
       {
-       // _logger.LogError(ex, "Неожиданная ошибка при отправке телеметрии в OpenAI");
+       _logger.LogError(ex, "Неожиданная ошибка при отправке телеметрии в OpenAI");
         result = ex.Message;
       }
       return result;
     }
     public async Task<string> GenerateImprovedContentAsync(string productInfo, string productDescription, CancellationToken cancellationToken = default)
     {
-      // _logger.LogInformation("Генерация улучшенного контента для продукта: {ProductInfo}", productInfo);
+      _logger.LogInformation("Генерация улучшенного контента для продукта: {ProductInfo}", productInfo);
 
       var chatRequest = new ChatRequest()
       {


### PR DESCRIPTION
## Summary
- очищены и упорядочены директивы using в OpenAIService
- внедрён ILogger<OpenAIService> через конструктор
- активированы ключевые вызовы LogInformation и LogError

## Testing
- `dotnet build >/tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_68a3a6c82aa4832f9663e8cb7d970b8d