### PR TITLE
Добавлен эндпоинт описания товара и модели атрибутов

### DIFF
--- a/Controllers/LLMOpenAPIController.cs
+++ b/Controllers/LLMOpenAPIController.cs
@@ -138,6 +138,46 @@ namespace ai_it_wiki.Controllers
             }
         }
 
+        /// <summary>
+        /// Получить описание товара по SKU
+        /// </summary>
+        [HttpPost("product/description")]
+        [SwaggerOperation(
+            Summary = "Получить описание товара",
+            Description = "Возвращает текстовое описание товара из Ozon API",
+            OperationId = "LLM_ProductDescription"
+        )]
+        [SwaggerResponse(StatusCodes.Status200OK, "OK", typeof(DescriptionItem))]
+        [ProducesResponseType(typeof(DescriptionItem), StatusCodes.Status200OK)]
+        public async Task<IActionResult> ProductDescriptionAsync(
+            [FromBody] ProductDescriptionRequest request,
+            CancellationToken cancellationToken
+        )
+        {
+            if (string.IsNullOrWhiteSpace(request?.Sku))
+            {
+                return BadRequest("SKU обязателен");
+            }
+
+            try
+            {
+                var description = await _ozonApiService.GetProductDescriptionAsync(
+                    request.Sku,
+                    cancellationToken
+                );
+                var result = new DescriptionItem { Sku = request.Sku, Description = description };
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ошибка при получении описания товара");
+                return StatusCode(
+                    StatusCodes.Status500InternalServerError,
+                    new ErrorResponse("Ошибка при получении описания товара", ex.Message)
+                );
+            }
+        }
+
         // /// <summary>
         // /// Получить рейтинг контента по одному SKU (детально)
         // /// </summary>

--- a/Models/Ozon/ProductAttributesRequest.cs
+++ b/Models/Ozon/ProductAttributesRequest.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ai_it_wiki.Models.Ozon
+{
+    /// <summary>
+    /// Запрос характеристик товаров
+    /// </summary>
+    public class ProductAttributesRequest
+    {
+        /// <summary>
+        /// Фильтр поиска
+        /// </summary>
+        [JsonPropertyName("filter")]
+        public ProductAttributesFilter Filter { get; set; } = new();
+
+        /// <summary>
+        /// Ограничение количества результатов
+        /// </summary>
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        /// <summary>
+        /// Направление сортировки
+        /// </summary>
+        [JsonPropertyName("sort_dir")]
+        public string? SortDir { get; set; }
+    }
+
+    /// <summary>
+    /// Фильтр для запроса характеристик
+    /// </summary>
+    public class ProductAttributesFilter
+    {
+        [JsonPropertyName("product_id")]
+        public List<long>? ProductId { get; set; }
+
+        [JsonPropertyName("offer_id")]
+        public List<string>? OfferId { get; set; }
+
+        [JsonPropertyName("sku")]
+        public List<string>? Sku { get; set; }
+
+        [JsonPropertyName("visibility")]
+        public string? Visibility { get; set; }
+    }
+}
+

--- a/Models/Ozon/ProductAttributesResponse.cs
+++ b/Models/Ozon/ProductAttributesResponse.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ai_it_wiki.Models.Ozon
+{
+    /// <summary>
+    /// Ответ на запрос характеристик товаров
+    /// </summary>
+    public class ProductAttributesResponse
+    {
+        [JsonPropertyName("result")]
+        public List<ProductAttributesItem>? Result { get; set; }
+
+        [JsonPropertyName("total")]
+        public int? Total { get; set; }
+
+        [JsonPropertyName("last_id")]
+        public string? LastId { get; set; }
+    }
+
+    /// <summary>
+    /// Элемент списка характеристик товара
+    /// </summary>
+    public class ProductAttributesItem
+    {
+        [JsonPropertyName("id")]
+        public long? Id { get; set; }
+
+        [JsonPropertyName("barcode")]
+        public string? Barcode { get; set; }
+
+        [JsonPropertyName("barcodes")]
+        public List<string>? Barcodes { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("offer_id")]
+        public string? OfferId { get; set; }
+
+        [JsonPropertyName("type_id")]
+        public long? TypeId { get; set; }
+
+        [JsonPropertyName("height")]
+        public decimal? Height { get; set; }
+
+        [JsonPropertyName("depth")]
+        public decimal? Depth { get; set; }
+
+        [JsonPropertyName("width")]
+        public decimal? Width { get; set; }
+
+        [JsonPropertyName("dimension_unit")]
+        public string? DimensionUnit { get; set; }
+
+        [JsonPropertyName("weight")]
+        public decimal? Weight { get; set; }
+
+        [JsonPropertyName("weight_unit")]
+        public string? WeightUnit { get; set; }
+
+        [JsonPropertyName("primary_image")]
+        public string? PrimaryImage { get; set; }
+
+        [JsonPropertyName("sku")]
+        public long? Sku { get; set; }
+
+        [JsonPropertyName("model_info")]
+        public ModelInfo? ModelInfo { get; set; }
+
+        [JsonPropertyName("images")]
+        public List<string>? Images { get; set; }
+
+        [JsonPropertyName("pdf_list")]
+        public List<string>? PdfList { get; set; }
+
+        [JsonPropertyName("attributes")]
+        public List<ProductAttributeInfo>? Attributes { get; set; }
+
+        [JsonPropertyName("attributes_with_defaults")]
+        public List<long>? AttributesWithDefaults { get; set; }
+
+        [JsonPropertyName("complex_attributes")]
+        public List<ProductAttributeInfo>? ComplexAttributes { get; set; }
+
+        [JsonPropertyName("color_image")]
+        public string? ColorImage { get; set; }
+
+        [JsonPropertyName("description_category_id")]
+        public long? DescriptionCategoryId { get; set; }
+    }
+
+    /// <summary>
+    /// Информация о модели товара
+    /// </summary>
+    public class ModelInfo
+    {
+        [JsonPropertyName("model_id")]
+        public long? ModelId { get; set; }
+
+        [JsonPropertyName("count")]
+        public int? Count { get; set; }
+    }
+
+    /// <summary>
+    /// Характеристика товара
+    /// </summary>
+    public class ProductAttributeInfo
+    {
+        [JsonPropertyName("id")]
+        public long? Id { get; set; }
+
+        [JsonPropertyName("complex_id")]
+        public long? ComplexId { get; set; }
+
+        [JsonPropertyName("values")]
+        public List<AttributeValue>? Values { get; set; }
+    }
+
+    /// <summary>
+    /// Значение характеристики товара
+    /// </summary>
+    public class AttributeValue
+    {
+        [JsonPropertyName("dictionary_value_id")]
+        public long? DictionaryValueId { get; set; }
+
+        [JsonPropertyName("value")]
+        public string? Value { get; set; }
+    }
+}
+

--- a/Models/Ozon/ProductDescriptionRequest.cs
+++ b/Models/Ozon/ProductDescriptionRequest.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace ai_it_wiki.Models.Ozon
+{
+    /// <summary>
+    /// Запрос описания товара по SKU
+    /// </summary>
+    public class ProductDescriptionRequest
+    {
+        /// <summary>
+        /// SKU товара
+        /// </summary>
+        [JsonPropertyName("sku")]
+        public string Sku { get; set; } = string.Empty;
+    }
+}
+

--- a/Services/Ozon/IOzonApiService.cs
+++ b/Services/Ozon/IOzonApiService.cs
@@ -36,6 +36,11 @@ namespace ai_it_wiki.Services.Ozon
             CancellationToken cancellationToken = default
         );
 
+        Task<ProductAttributesResponse> GetAttributesAsync(
+            ProductAttributesRequest request,
+            CancellationToken cancellationToken = default
+        );
+
         //TODO[critical]: исправить методы получения информации о продуктах и самого списка продуктов
     }
 }


### PR DESCRIPTION
## Summary
- Реализован POST эндпоинт `/llm/product/description` для получения описания товара по SKU
- Добавлены модели запросов и ответов для описания товара и характеристик продуктов
- Расширен интерфейс `IOzonApiService` методом получения характеристик

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68a4042067c4832fbe85f87f840b63af