### PR TITLE
Добавлен параметр includeRatings для рейтинга товаров

### DIFF
--- a/Controllers/LLMOpenAPIController.cs
+++ b/Controllers/LLMOpenAPIController.cs
@@ -286,8 +286,9 @@ namespace ai_it_wiki.Controllers
         /// <param name="lastId">Пагинация: last_id (необязательно)</param>
         /// <param name="limit">Пагинация: limit (по умолчанию 1000)</param>
         /// <param name="fields">Необязательный список полей, которые нужно включить в ответ. Если не задан — вернётся полный объект.</param>
-        /// <param name="part">Номер части ответа (начиная с 1). Если ответ превышает лимит токенов, контент будет возвращён по частям.</param>
         /// <param name="cancellationToken">Токен отмены</param>
+        /// <param name="includeRatings">При значении <c>true</c> дополнительно запрашивает рейтинг товаров по SKU и добавляет его в результат</param>
+        /// <param name="part">Номер части ответа (начиная с 1). Если ответ превышает лимит токенов, контент будет возвращён по частям.</param>
         [HttpGet("products")]
         [SwaggerOperation(
             Summary = "Получить список товаров",
@@ -312,6 +313,7 @@ namespace ai_it_wiki.Controllers
             [FromQuery] int? limit,
             [FromQuery] List<string>? fields,
             CancellationToken cancellationToken,
+            [FromQuery] bool includeRatings = false,
             [FromQuery] int part = 1,
             [FromQuery] string? mode = null
         )
@@ -333,6 +335,36 @@ namespace ai_it_wiki.Controllers
             try
             {
                 var result = await _ozonApiService.GetProductsAsync(request, cancellationToken);
+
+                if (includeRatings)
+                {
+                    var skuList = result
+                        .Select(r => r.Sku)
+                        .Where(s => s != 0)
+                        .Distinct()
+                        .ToList();
+
+                    if (skuList.Any())
+                    {
+                        var ratingResponse = await _ozonApiService.GetRatingBySkusAsync(
+                            new RatingRequest { Skus = skuList },
+                            cancellationToken
+                        );
+
+                        var ratingDict = ratingResponse.Products
+                            .ToDictionary(p => p.Sku);
+
+                        foreach (var item in result)
+                        {
+                            if (ratingDict.TryGetValue(item.Sku, out var rating))
+                            {
+                                item.Rating = rating.Rating;
+                                item.Groups = rating.Groups;
+                            }
+                        }
+                    }
+                }
+
                 var shaped = ShapeResponse(result, fields);
                 return SplitedResponse(shaped, part, ParseMode(mode));
             }
@@ -580,6 +612,8 @@ namespace ai_it_wiki.Controllers
             "description_category_id",
             "attributes",
             "items",
+            "rating",
+            "groups",
         };
 
         private static readonly HashSet<string> AllowedProductDescriptionFields = new(
@@ -722,10 +756,16 @@ namespace ai_it_wiki.Controllers
                                 dict["product_id"] = it.ProductId;
                             if (requested.Contains("offer_id"))
                                 dict["offer_id"] = it.OfferId;
+                            if (requested.Contains("sku"))
+                                dict["sku"] = it.Sku;
                             if (requested.Contains("has_fbo_stocks"))
                                 dict["has_fbo_stocks"] = it.HasFboStocks;
                             if (requested.Contains("is_discounted"))
                                 dict["is_discounted"] = it.IsDiscounted;
+                            if (requested.Contains("rating"))
+                                dict["rating"] = it.Rating;
+                            if (requested.Contains("groups"))
+                                dict["groups"] = it.Groups;
                             return dict;
                         })
                         .ToList();

--- a/Models/Ozon/ProductInfoListResponse.cs
+++ b/Models/Ozon/ProductInfoListResponse.cs
@@ -364,6 +364,15 @@ namespace ai_it_wiki.Models.Ozon
 
         [JsonPropertyName("quants")]
         public List<object> Quants { get; set; }
+
+        [JsonPropertyName("sku")]
+        public long Sku { get; set; }
+
+        [JsonPropertyName("rating"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public double? Rating { get; set; }
+
+        [JsonPropertyName("groups"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<RatingGroup>? Groups { get; set; }
     }
 
     public class ProductInfoListRequest


### PR DESCRIPTION
## Изменения
- Добавлен параметр `includeRatings` для `/llm/products` и подгрузка рейтингов по SKU
- Расширены выбираемые поля товаров рейтингами и их группами
- Расширена модель `ProductListItem` полями SKU и рейтинга

## Тестирование
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dcd4dd50832f835838fbe2b475e2