### PR TITLE
Добавлен флаг includeDescription и поддержка описаний товаров

### DIFF
--- a/Models/Ozon/ProductInfoListResponse.cs
+++ b/Models/Ozon/ProductInfoListResponse.cs
@@ -169,6 +169,12 @@ namespace ai_it_wiki.Models.Ozon
 
         [JsonPropertyName("sku")]
         public long Sku { get; set; }
+
+        /// <summary>
+        /// Описание товара, доступно при запросе поля <c>description</c>.
+        /// </summary>
+        [JsonPropertyName("description"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Description { get; set; }
     }
 
     public class ProductSource
@@ -370,6 +376,12 @@ namespace ai_it_wiki.Models.Ozon
     {
         [JsonPropertyName("product_id")]
         public List<long> ProductId { get; set; } = new List<long>();
+
+        /// <summary>
+        /// Набор полей, которые необходимо вернуть. Например, <c>description</c>.
+        /// </summary>
+        [JsonPropertyName("fields"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public List<string>? Fields { get; set; }
     }
 
     public class RatingRequest
@@ -394,6 +406,12 @@ namespace ai_it_wiki.Models.Ozon
 
         [JsonPropertyName("groups")]
         public List<RatingGroup> Groups { get; set; }
+
+        /// <summary>
+        /// Описание товара, подставляется вручную при запросе расширенной информации.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? Description { get; set; }
     }
 
     public class RatingGroup

--- a/Services/Ozon/IOzonApiService.cs
+++ b/Services/Ozon/IOzonApiService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ai_it_wiki.Models.Ozon;
@@ -38,6 +39,16 @@ namespace ai_it_wiki.Services.Ozon
 
         Task<ProductAttributesResponse> GetAttributesAsync(
             ProductAttributesRequest request,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Получить описания товаров по их идентификаторам.
+        /// </summary>
+        /// <param name="productIds">Список идентификаторов товаров.</param>
+        /// <param name="cancellationToken">Токен отмены.</param>
+        Task<Dictionary<long, string?>> GetProductDescriptionsAsync(
+            IEnumerable<long> productIds,
             CancellationToken cancellationToken = default
         );
 

--- a/Services/Ozon/OzonApiService.cs
+++ b/Services/Ozon/OzonApiService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -170,6 +172,27 @@ namespace ai_it_wiki.Services.Ozon
                     ex
                 );
             }
+        }
+
+        /// <summary>
+        /// Возвращает словарь описаний товаров по их идентификаторам.
+        /// </summary>
+        /// <param name="productIds">Список идентификаторов товаров (SKU).</param>
+        /// <param name="cancellationToken">Токен отмены.</param>
+        public async Task<Dictionary<long, string?>> GetProductDescriptionsAsync(
+            IEnumerable<long> productIds,
+            CancellationToken cancellationToken = default
+        )
+        {
+            var request = new ProductInfoListRequest
+            {
+                ProductId = productIds.ToList(),
+                Fields = new List<string> { "description" },
+            };
+
+            var response = await GetProductInfoListAsync(request, cancellationToken);
+            return response.Items?.ToDictionary(i => i.Id, i => i.Description)
+                ?? new Dictionary<long, string?>();
         }
 
         public async Task<List<ProductListItem>> GetProductsAsync(


### PR DESCRIPTION
## Обзор
- расширен сервис OzonAPI методом для пакетного получения описаний
- реализована поддержка поля `description` и флага `includeDescription` в контроллере `LLMOpenAPIController`
- обновлены модели для работы с описаниями и их выборочной выдачей

## Тестирование
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd0bd3ac832f885ad3260bb7ed19